### PR TITLE
Feat/suppress leave application message

### DIFF
--- a/workplan/hooks.py
+++ b/workplan/hooks.py
@@ -132,9 +132,9 @@ app_license = "agpl-3.0"
 # ---------------
 # Override standard doctype classes
 
-# override_doctype_class = {
-# 	"Leave Application": "workplan.workplan.overrides.leave_application.CustomLeaveApplication"
-# }
+override_doctype_class = {
+	"Leave Application": "workplan.workplan.overrides.leave_application_warning_suppress.CustomLeaveApplication"
+}
 
 # Document Events
 # ---------------

--- a/workplan/workplan/overrides/leave_application_warning_suppress.py
+++ b/workplan/workplan/overrides/leave_application_warning_suppress.py
@@ -1,0 +1,34 @@
+import frappe
+from frappe import _
+from hrms.hr.doctype.leave_application.leave_application import get_leave_allocation_records 
+from hrms.hr.doctype.leave_application.leave_application import LeaveApplication, InsufficientLeaveBalanceError
+
+class CustomLeaveApplication(LeaveApplication):
+    def show_insufficient_balance_message(self, leave_balance_for_consumption: float) -> None:
+        allocation = get_leave_allocation_records(self.employee, self.from_date, self.leave_type)
+        total = allocation[self.leave_type].total_leaves_allocated
+        if total > 0:
+            # core show_insufficient_balance_message function
+            alloc_on_from_date, alloc_on_to_date = self.get_allocation_based_on_application_dates()
+
+            if frappe.db.get_value("Leave Type", self.leave_type, "allow_negative"):
+                if leave_balance_for_consumption != self.leave_balance:
+                    msg = _("Warning: Insufficient leave balance for Leave Type {0} in this allocation.").format(
+                        frappe.bold(self.leave_type)
+                    )
+                    msg += "<br><br>"
+                    msg += _(
+                        "Actual balances aren't available because the leave application spans over different leave allocations. You can still apply for leaves which would be compensated during the next allocation."
+                    )
+                else:
+                    msg = _("Warning: Insufficient leave balance for Leave Type {0}.").format(
+                        frappe.bold(self.leave_type)
+                    )
+
+                frappe.msgprint(msg, title=_("Warning"), indicator="orange")
+            else:
+                frappe.throw(
+                    _("Insufficient leave balance for Leave Type {0}").format(frappe.bold(self.leave_type)),
+                    exc=InsufficientLeaveBalanceError,
+                    title=_("Insufficient Balance"),
+                )

--- a/workplan/workplan/overrides/leave_application_warning_suppress.py
+++ b/workplan/workplan/overrides/leave_application_warning_suppress.py
@@ -11,27 +11,28 @@ class CustomLeaveApplication(LeaveApplication):
 	def show_insufficient_balance_message(self, leave_balance_for_consumption: float) -> None:
 		allocation = get_leave_allocation_records(self.employee, self.from_date, self.leave_type)
 		if allocation[self.leave_type] and allocation[self.leave_type].total_leaves_allocated == 0:
-			# core show_insufficient_balance_message function
-			alloc_on_from_date, alloc_on_to_date = self.get_allocation_based_on_application_dates()
+			return
+		# core show_insufficient_balance_message function
+		alloc_on_from_date, alloc_on_to_date = self.get_allocation_based_on_application_dates()
 
-			if frappe.db.get_value("Leave Type", self.leave_type, "allow_negative"):
-				if leave_balance_for_consumption != self.leave_balance:
-					msg = _(
-						"Warning: Insufficient leave balance for Leave Type {0} in this allocation."
-					).format(frappe.bold(self.leave_type))
-					msg += "<br><br>"
-					msg += _(
-						"Actual balances aren't available because the leave application spans over different leave allocations. You can still apply for leaves which would be compensated during the next allocation."
-					)
-				else:
-					msg = _("Warning: Insufficient leave balance for Leave Type {0}.").format(
-						frappe.bold(self.leave_type)
-					)
-
-				frappe.msgprint(msg, title=_("Warning"), indicator="orange")
-			else:
-				frappe.throw(
-					_("Insufficient leave balance for Leave Type {0}").format(frappe.bold(self.leave_type)),
-					exc=InsufficientLeaveBalanceError,
-					title=_("Insufficient Balance"),
+		if frappe.db.get_value("Leave Type", self.leave_type, "allow_negative"):
+			if leave_balance_for_consumption != self.leave_balance:
+				msg = _("Warning: Insufficient leave balance for Leave Type {0} in this allocation.").format(
+					frappe.bold(self.leave_type)
 				)
+				msg += "<br><br>"
+				msg += _(
+					"Actual balances aren't available because the leave application spans over different leave allocations. You can still apply for leaves which would be compensated during the next allocation."
+				)
+			else:
+				msg = _("Warning: Insufficient leave balance for Leave Type {0}.").format(
+					frappe.bold(self.leave_type)
+				)
+
+			frappe.msgprint(msg, title=_("Warning"), indicator="orange")
+		else:
+			frappe.throw(
+				_("Insufficient leave balance for Leave Type {0}").format(frappe.bold(self.leave_type)),
+				exc=InsufficientLeaveBalanceError,
+				title=_("Insufficient Balance"),
+			)

--- a/workplan/workplan/overrides/leave_application_warning_suppress.py
+++ b/workplan/workplan/overrides/leave_application_warning_suppress.py
@@ -1,34 +1,38 @@
 import frappe
 from frappe import _
-from hrms.hr.doctype.leave_application.leave_application import get_leave_allocation_records 
-from hrms.hr.doctype.leave_application.leave_application import LeaveApplication, InsufficientLeaveBalanceError
+from hrms.hr.doctype.leave_application.leave_application import (
+	InsufficientLeaveBalanceError,
+	LeaveApplication,
+	get_leave_allocation_records,
+)
+
 
 class CustomLeaveApplication(LeaveApplication):
-    def show_insufficient_balance_message(self, leave_balance_for_consumption: float) -> None:
-        allocation = get_leave_allocation_records(self.employee, self.from_date, self.leave_type)
-        total = allocation[self.leave_type].total_leaves_allocated
-        if total > 0:
-            # core show_insufficient_balance_message function
-            alloc_on_from_date, alloc_on_to_date = self.get_allocation_based_on_application_dates()
+	def show_insufficient_balance_message(self, leave_balance_for_consumption: float) -> None:
+		allocation = get_leave_allocation_records(self.employee, self.from_date, self.leave_type)
+		total = allocation[self.leave_type].total_leaves_allocated
+		if total > 0:
+			# core show_insufficient_balance_message function
+			alloc_on_from_date, alloc_on_to_date = self.get_allocation_based_on_application_dates()
 
-            if frappe.db.get_value("Leave Type", self.leave_type, "allow_negative"):
-                if leave_balance_for_consumption != self.leave_balance:
-                    msg = _("Warning: Insufficient leave balance for Leave Type {0} in this allocation.").format(
-                        frappe.bold(self.leave_type)
-                    )
-                    msg += "<br><br>"
-                    msg += _(
-                        "Actual balances aren't available because the leave application spans over different leave allocations. You can still apply for leaves which would be compensated during the next allocation."
-                    )
-                else:
-                    msg = _("Warning: Insufficient leave balance for Leave Type {0}.").format(
-                        frappe.bold(self.leave_type)
-                    )
+			if frappe.db.get_value("Leave Type", self.leave_type, "allow_negative"):
+				if leave_balance_for_consumption != self.leave_balance:
+					msg = _(
+						"Warning: Insufficient leave balance for Leave Type {0} in this allocation."
+					).format(frappe.bold(self.leave_type))
+					msg += "<br><br>"
+					msg += _(
+						"Actual balances aren't available because the leave application spans over different leave allocations. You can still apply for leaves which would be compensated during the next allocation."
+					)
+				else:
+					msg = _("Warning: Insufficient leave balance for Leave Type {0}.").format(
+						frappe.bold(self.leave_type)
+					)
 
-                frappe.msgprint(msg, title=_("Warning"), indicator="orange")
-            else:
-                frappe.throw(
-                    _("Insufficient leave balance for Leave Type {0}").format(frappe.bold(self.leave_type)),
-                    exc=InsufficientLeaveBalanceError,
-                    title=_("Insufficient Balance"),
-                )
+				frappe.msgprint(msg, title=_("Warning"), indicator="orange")
+			else:
+				frappe.throw(
+					_("Insufficient leave balance for Leave Type {0}").format(frappe.bold(self.leave_type)),
+					exc=InsufficientLeaveBalanceError,
+					title=_("Insufficient Balance"),
+				)

--- a/workplan/workplan/overrides/leave_application_warning_suppress.py
+++ b/workplan/workplan/overrides/leave_application_warning_suppress.py
@@ -10,8 +10,7 @@ from hrms.hr.doctype.leave_application.leave_application import (
 class CustomLeaveApplication(LeaveApplication):
 	def show_insufficient_balance_message(self, leave_balance_for_consumption: float) -> None:
 		allocation = get_leave_allocation_records(self.employee, self.from_date, self.leave_type)
-		total = allocation[self.leave_type].total_leaves_allocated
-		if total > 0:
+		if allocation[self.leave_type] and allocation[self.leave_type].total_leaves_allocated == 0:
 			# core show_insufficient_balance_message function
 			alloc_on_from_date, alloc_on_to_date = self.get_allocation_based_on_application_dates()
 


### PR DESCRIPTION
If the leave allocation for the leave type is 0 no warning for insufficient leave balance is shown when creating a leave application
If the leave allocation is >0 the warning still gets shown if leave balance is too small