### PR TITLE
fix carry forward for current year, remove outdated hook

### DIFF
--- a/workplan/hooks.py
+++ b/workplan/hooks.py
@@ -141,7 +141,6 @@ override_doctype_class = {
 # Hook on document methods and events
 
 doc_events = {
-	"Leave Allocation": {"before_insert": "workplan.workplan.overrides.leave_allocation.update"},
 	"Employee": {
 		"before_save": "workplan.workplan.overrides.leave_allocation_new.update_all_allocations",
 		"validate": "workplan.workplan.overrides.workplan_validation.validate_workplans",

--- a/workplan/patches.txt
+++ b/workplan/patches.txt
@@ -5,3 +5,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 workplan.workplan.patches.set_workplans
+workplan.workplan.patches.fix_carry_forward

--- a/workplan/workplan/overrides/leave_allocation_new.py
+++ b/workplan/workplan/overrides/leave_allocation_new.py
@@ -201,7 +201,18 @@ def calc_allocation_value(employee_doc, from_date, leave_type):
 			days_allocated += days_allocated_in_workplan
 			workplan = get_next_workplan(employee_doc, end)
 
-	if leave_type_doc.is_carry_forward and from_date.year == today.year:
+	allocation_name = get_allocation_name(employee_doc.name, leave_type_doc.name, last_day)
+
+	allocation_doc = None
+	if allocation_name:
+		allocation_doc = frappe.get_doc("Leave Allocation", allocation_name)
+
+	# if the allocation has carry_forward already set (only human created allocations) no additional carry forward is set
+	if (
+		leave_type_doc.is_carry_forward
+		and from_date.year == today.year
+		and not (allocation_doc and allocation_doc.carry_forward == 1)
+	):
 		last_day_last_year = getdate(f"{from_date.year-1}-12-31")
 		carry_forward_days = get_carry_forward_days(employee_doc, leave_type, last_day_last_year)
 		days_allocated += carry_forward_days

--- a/workplan/workplan/patches/fix_carry_forward.py
+++ b/workplan/workplan/patches/fix_carry_forward.py
@@ -1,0 +1,14 @@
+import frappe
+from frappe.utils import getdate
+
+from workplan.workplan.overrides.leave_allocation_new import update_allocation_for_year
+
+
+def execute():
+	employees = frappe.get_all("Employee")
+	for employee in employees:
+		employee_doc = frappe.get_doc("Employee", employee)
+		if employee_doc.custom_workplans:
+			today = getdate()
+			first_day_this_year = getdate(f"{today.year}-01-01")
+			update_allocation_for_year(employee_doc, first_day_this_year, today)


### PR DESCRIPTION
Checks for carry_forward check in current Leave Allocation. If its set no additional carry forward gets calculated. Recalculates current year's Allocations with a patch.